### PR TITLE
Improve the XML Mapping Driver tests for XSD validation

### DIFF
--- a/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
@@ -1874,3 +1874,11 @@ class ReservedWordInTableColumn
         );
     }
 }
+
+class UserIncorrectAttributes extends User
+{
+}
+
+class UserMissingAttributes extends User
+{
+}

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.ORM.Mapping.UserIncorrectAttributes.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.ORM.Mapping.UserIncorrectAttributes.dcm.xml
@@ -5,7 +5,7 @@
                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
                           https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
-    <entity name="Doctrine\Tests\ORM\Mapping\User" table="cms_users">
+    <entity name="Doctrine\Tests\ORM\Mapping\UserIncorrectAttributes" table="cms_users">
         <unique-constraints>
             <unique-constraint columns="name,user_email" name="search_idx">
                 <options>

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.ORM.Mapping.UserMissingAttributes.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.ORM.Mapping.UserMissingAttributes.dcm.xml
@@ -5,7 +5,7 @@
                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
                           https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
-    <entity name="Doctrine\Tests\ORM\Mapping\User" table="cms_users">
+    <entity name="Doctrine\Tests\ORM\Mapping\UserMissingAttributes" table="cms_users">
         <id name="id" type="integer" column="id">
             <generator strategy="AUTO"/>
             <sequence-generator sequence-name="tablename_seq" allocation-size="100" initial-value="1" />


### PR DESCRIPTION
As concluded in the main PR thread, I adjusted the tests to use the same workflow as the real conditions would have. This way we have the same errors after XSD validation. It also simplifies the tests and allows us to do a bit more assertions than before.