### PR TITLE
Disable XSD validation by default

### DIFF
--- a/lib/Doctrine/ORM/ORMSetup.php
+++ b/lib/Doctrine/ORM/ORMSetup.php
@@ -101,10 +101,11 @@ final class ORMSetup
         array $paths,
         bool $isDevMode = false,
         ?string $proxyDir = null,
-        ?CacheItemPoolInterface $cache = null
+        ?CacheItemPoolInterface $cache = null,
+        ?bool $isXsdValidationEnabled = false
     ): Configuration {
         $config = self::createConfiguration($isDevMode, $proxyDir, $cache);
-        $config->setMetadataDriverImpl(new XmlDriver($paths));
+        $config->setMetadataDriverImpl(new XmlDriver($paths, $isXsdValidationEnabled));
 
         return $config;
     }

--- a/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
@@ -33,7 +33,11 @@ class XmlMappingDriverTest extends AbstractMappingDriverTest
 {
     protected function loadDriver(): MappingDriver
     {
-        return new XmlDriver(__DIR__ . DIRECTORY_SEPARATOR . 'xml');
+        return new XmlDriver(
+            __DIR__ . DIRECTORY_SEPARATOR . 'xml',
+            XmlDriver::DEFAULT_FILE_EXTENSION,
+            true
+        );
     }
 
     public function testClassTableInheritanceDiscriminatorMap(): void


### PR DESCRIPTION
Add a deprecation to warn about 3.0 default activation